### PR TITLE
Add third version of event, including a field rename.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ project/plugins/project/
 # Mongo Explorer plugin:
 .idea/mongoSettings.xml
 
+.idea/
+
 ## File-based project format:
 *.iws
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,8 +17,10 @@ akka {
         }
 
         event-adapter-bindings {
-          // V1 ~> V2
+          // V1 ~> V3
           "com.experiments.calvin.models.ShoppingCartV1" = shoppingCartAdapter
+          // V2 ~> V3
+          "com.experiments.calvin.models.ShoppingCartV2" = shoppingCartAdapter
         }
       }
     }
@@ -41,6 +43,7 @@ akka {
     serialization-bindings {
       "com.experiments.calvin.models.ShoppingCartV1" = shoppingCart
       "com.experiments.calvin.models.ShoppingCartV2" = shoppingCart
+      "com.experiments.calvin.models.ShoppingCartV3" = shoppingCart
     }
   }
 }

--- a/src/main/scala/com/experiments/calvin/Main.scala
+++ b/src/main/scala/com/experiments/calvin/Main.scala
@@ -6,17 +6,17 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.experiments.calvin.actors.ShoppingCartActor
 import com.experiments.calvin.actors.ShoppingCartActor.GetResult
-import com.experiments.calvin.models.{ItemV2, ShoppingCartV2}
+import com.experiments.calvin.models.{ShoppingCartV3, ItemV3}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 object Main extends App {
-  val shoppingCart = ShoppingCartV2(
+  val shoppingCart = ShoppingCartV3(
     List(
-      ItemV2(1, "lays chips", "cant have just one bite"),
-      ItemV2(2, "caramilk chocolate", "calories")
+      ItemV3(1, "lays chips", "cant have just one bite"),
+      ItemV3(2, "caramilk chocolate", "calories")
     )
   )
 
@@ -24,7 +24,7 @@ object Main extends App {
   val actorSystem = ActorSystem(name = "example")
   val shoppingCartActor = actorSystem.actorOf(Props[ShoppingCartActor], name = "shopping-cart-actor")
   shoppingCartActor ! shoppingCart
-  val futureResult = (shoppingCartActor ? GetResult).mapTo[ShoppingCartV2]
+  val futureResult = (shoppingCartActor ? GetResult).mapTo[ShoppingCartV3]
   val obtainedCart = Await.result(futureResult, 10 seconds)
   println(obtainedCart)
   actorSystem.terminate()

--- a/src/main/scala/com/experiments/calvin/actors/ShoppingCartActor.scala
+++ b/src/main/scala/com/experiments/calvin/actors/ShoppingCartActor.scala
@@ -3,25 +3,25 @@ package com.experiments.calvin.actors
 import akka.actor.ActorLogging
 import akka.persistence.PersistentActor
 import com.experiments.calvin.actors.ShoppingCartActor.GetResult
-import com.experiments.calvin.models.{ShoppingCartV1, ShoppingCartV2}
+import com.experiments.calvin.models.ShoppingCartV3
 
 class ShoppingCartActor extends PersistentActor with ActorLogging {
-  var state = ShoppingCartV2(List.empty)
+  var state = ShoppingCartV3(List.empty)
 
-  val updateState: ShoppingCartV2 => Unit = {
-    sc: ShoppingCartV2 => state = sc
+  val updateState: ShoppingCartV3 => Unit = {
+    sc: ShoppingCartV3 => state = sc
   }
 
   override def persistenceId: String = "shopping-cart-persistent-actor"
 
   override def receiveRecover: Receive = {
-    case sc: ShoppingCartV2 =>
+    case sc: ShoppingCartV3 =>
       log.info("recovering Shopping Cart from journal: {}", sc)
       updateState(sc)
   }
 
   override def receiveCommand: Receive = {
-    case sc: ShoppingCartV2 => persist(sc)(updateState)
+    case sc: ShoppingCartV3 => persist(sc)(updateState)
     case GetResult => sender() ! state
   }
 }

--- a/src/main/scala/com/experiments/calvin/eventadapters/ShoppingCartEventAdapter.scala
+++ b/src/main/scala/com/experiments/calvin/eventadapters/ShoppingCartEventAdapter.scala
@@ -1,7 +1,7 @@
 package com.experiments.calvin.eventadapters
 
 import akka.persistence.journal.{EventAdapter, EventSeq}
-import com.experiments.calvin.models.{ItemV2, ShoppingCartV1, ShoppingCartV2}
+import com.experiments.calvin.models._
 
 /**
   * This class upgrades old events from the event journal
@@ -22,14 +22,19 @@ class ShoppingCartEventAdapter extends EventAdapter {
 
   override def fromJournal(event: Any, manifest: String): EventSeq = event match {
     case sc @ ShoppingCartV1(itemsV1) =>
-      println("Reading V1 from journal and doing promotion to V2")
+      println("Reading V1 from journal and doing promotion to V3")
       EventSeq(
       // do promotion
-      ShoppingCartV2(itemsV1.map(each => ItemV2(each.id, each.name, "")))
+      ShoppingCartV3(itemsV1.map(each => ItemV3(each.id, each.name, "")))
     )
-
-    case sc: ShoppingCartV2 =>
-      println("V2 event encountered, no promotion needed")
+    case sc @ ShoppingCartV2(itemsV2) =>
+      println("Reading V2 from journal and doing promotion to V3")
+      EventSeq(
+      // do promotion
+      ShoppingCartV3(itemsV2.map(each => ItemV3(each.id, each.name, each.description)))
+    )
+    case sc: ShoppingCartV3 =>
+      println("V3 event encountered, no promotion needed")
       EventSeq(sc)
   }
 }

--- a/src/main/scala/com/experiments/calvin/models/ItemV3.scala
+++ b/src/main/scala/com/experiments/calvin/models/ItemV3.scala
@@ -1,0 +1,3 @@
+package com.experiments.calvin.models
+
+case class ItemV3(id: Int, fullName: String, description: String)

--- a/src/main/scala/com/experiments/calvin/models/ShoppingCartV3.scala
+++ b/src/main/scala/com/experiments/calvin/models/ShoppingCartV3.scala
@@ -1,0 +1,4 @@
+package com.experiments.calvin.models
+
+case class ShoppingCartV3(items: List[ItemV3])
+


### PR DESCRIPTION
It would be interesting to add the typical examples of schema evolution to see how they're managed on the event adapters.
